### PR TITLE
Update retired badge from shield.io to vsmarketplacebadges.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@
 [![Rocket MV BASIC Docs](https://img.shields.io/badge/Rocket%20MV%20BASIC-Marketplace-brightgreen?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=RocketSoftware.rocket-mvbasic)
 [![Rocket MV BASIC Docs](https://img.shields.io/badge/Rocket%20MV%20BASIC-Docs-brightgreen?style=flat-square)](https://rocketsoftware.github.io/rocket-mvbasic/)
 [![Rocket MV BASIC Docs](https://img.shields.io/badge/Rocket%20MV%20BASIC-Forum-brightgreen?style=flat-square)](https://community.rocketsoftware.com/forums/multivalue?CommunityKey=521bce2e-71d5-4d32-b560-dfa95e950eb5)
+![Visual Studio Marketplace Version](https://vsmarketplacebadges.dev/version/rocketsoftware.rocket-mvbasic.svg?style=flat-square)
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/new/#https://github.com/RocketSoftware/rocket-mvbasic)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,5 @@
 [![Rocket MV BASIC Docs](https://img.shields.io/badge/Rocket%20MV%20BASIC-Marketplace-brightgreen?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=RocketSoftware.rocket-mvbasic)
 [![Rocket MV BASIC Docs](https://img.shields.io/badge/Rocket%20MV%20BASIC-Docs-brightgreen?style=flat-square)](https://rocketsoftware.github.io/rocket-mvbasic/)
 [![Rocket MV BASIC Docs](https://img.shields.io/badge/Rocket%20MV%20BASIC-Forum-brightgreen?style=flat-square)](https://community.rocketsoftware.com/forums/multivalue?CommunityKey=521bce2e-71d5-4d32-b560-dfa95e950eb5)
-![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/rocketsoftware.rocket-mvbasic?style=flat-square)
-
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/new/#https://github.com/RocketSoftware/rocket-mvbasic)


### PR DESCRIPTION
The Visual Studio Marketplace Version badge is deprecated. will use https://vsmarketplacebadges.dev/ instead.

<img width="268" height="36" alt="image" src="https://github.com/user-attachments/assets/51fff585-db6d-47fa-b2ad-8779d738a715" />

Ref: https://github.com/badges/shields/pull/11792
